### PR TITLE
feat: ID-1889: take viewing distance into account when panning

### DIFF
--- a/core/src/main/java/ab/j3d/control/FromToCameraControl.java
+++ b/core/src/main/java/ab/j3d/control/FromToCameraControl.java
@@ -93,13 +93,6 @@ public class FromToCameraControl
 	private Matrix3D _dragStartScene2View = Matrix3D.IDENTITY;
 
 	/**
-	 * Zoom factor when dragging started.
-	 * <p />
-	 * This is used as temporary state variable for dragging operations.
-	 */
-	private double _dragStartZoomFactor = 1.0;
-
-	/**
 	 * Distance of target point, relative to view position, when dragging started.
 	 * <p />
 	 * This is used as temporary state variable for dragging operations.
@@ -445,7 +438,6 @@ public class FromToCameraControl
 	public void mousePressed( final ControlInputEvent event )
 	{
 		_dragStartScene2View = getScene2View();
-		_dragStartZoomFactor = _view.getZoomFactor();
 		_dragStartDistance = _distance;
 
 		super.mousePressed( event );

--- a/core/src/main/java/ab/j3d/control/FromToCameraControl.java
+++ b/core/src/main/java/ab/j3d/control/FromToCameraControl.java
@@ -616,15 +616,10 @@ public class FromToCameraControl
 	 */
 	protected void pan( final ControlInputEvent event )
 	{
-		final Matrix3D scene2view = _dragStartScene2View;
-
-//		final double toUnits = view.getPixelsToUnitsFactor();
-		final double toUnits = 0.01 * _dragStartDistance;
-
-		final double dx =  toUnits * (double)event.getDragDeltaX();
-		final double dy = -toUnits * (double)event.getDragDeltaY();
-
-		setScene2View( scene2view.plus( dx, dy, 0.0 ) );
+		double toUnits = _view.getProjector().imageToViewScale( getDistance() );
+		double dx = toUnits * event.getDragDeltaX();
+		double dy = -toUnits * event.getDragDeltaY();
+		setScene2View( _dragStartScene2View.plus( dx, dy, 0 ) );
 	}
 
 	/**

--- a/core/src/main/java/ab/j3d/control/FromToCameraControl.java
+++ b/core/src/main/java/ab/j3d/control/FromToCameraControl.java
@@ -1,5 +1,4 @@
-/* $Id$
- * ====================================================================
+/*
  * AsoBrain 3D Toolkit
  * Copyright (C) 1999-2011 Peter S. Heijnen
  *
@@ -15,7 +14,6 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * ====================================================================
  */
 package ab.j3d.control;
 
@@ -48,10 +46,9 @@ import org.jetbrains.annotations.*;
  *  <dd>Moves both the 'to' and 'from' point in the current view direction.
  * </dl>
  *
- * @author  G.B.M. Rupert
- * @author  G. Meinders
- * @author  Peter S. Heijnen
- * @version $Revision$ $Date$
+ * @author G.B.M. Rupert
+ * @author G. Meinders
+ * @author Peter S. Heijnen
  */
 public class FromToCameraControl
 	extends CameraControl

--- a/core/src/main/java/ab/j3d/control/OrbitCameraControl.java
+++ b/core/src/main/java/ab/j3d/control/OrbitCameraControl.java
@@ -1,5 +1,4 @@
-/* $Id$
- * ====================================================================
+/*
  * AsoBrain 3D Toolkit
  * Copyright (C) 1999-2011 Peter S. Heijnen
  *
@@ -16,7 +15,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- * ====================================================================
  */
 package ab.j3d.control;
 
@@ -41,9 +39,8 @@ import ab.j3d.view.*;
  *      mouse up or down.</dd>
  * </dl>
  *
- * @author  Peter S. Heijnen
- * @author  G.B.M. Rupert
- * @version $Revision$ $Date$
+ * @author Peter S. Heijnen
+ * @author G.B.M. Rupert
  *
  * @deprecated For removal, since 1.24.0. These controls are outdated. Use {@link FromToCameraControl} instead.
  */

--- a/core/src/main/java/ab/j3d/control/OrbitCameraControl.java
+++ b/core/src/main/java/ab/j3d/control/OrbitCameraControl.java
@@ -44,7 +44,10 @@ import ab.j3d.view.*;
  * @author  Peter S. Heijnen
  * @author  G.B.M. Rupert
  * @version $Revision$ $Date$
+ *
+ * @deprecated For removal, since 1.24.0. These controls are outdated. Use {@link FromToCameraControl} instead.
  */
+@Deprecated
 public class OrbitCameraControl
 	extends CameraControl
 {

--- a/core/src/main/java/ab/j3d/control/PanAndZoomCameraControl.java
+++ b/core/src/main/java/ab/j3d/control/PanAndZoomCameraControl.java
@@ -1,5 +1,4 @@
-/* $Id$
- * ====================================================================
+/*
  * AsoBrain 3D Toolkit
  * Copyright (C) 1999-2011 Peter S. Heijnen
  *
@@ -15,7 +14,6 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * ====================================================================
  */
 package ab.j3d.control;
 
@@ -29,13 +27,12 @@ import org.jetbrains.annotations.*;
 /**
  * This class implements a camera control that allows only camera panning and
  * zooming.
- * <p />
+ * <p>
  * Panning is achieved by modifying the translational components of the view
  * matrix ({@link View3D#setScene2View}, while the zoom effect is
  * achieved by manipulating the view's zoom factor ({@link View3D#setZoomFactor}.
  *
- * @author  Peter S. Heijnen
- * @version $Revision$ $Date$
+ * @author Peter S. Heijnen
  */
 public class PanAndZoomCameraControl
 	extends CameraControl

--- a/core/src/main/java/ab/j3d/control/PanAndZoomCameraControl.java
+++ b/core/src/main/java/ab/j3d/control/PanAndZoomCameraControl.java
@@ -194,15 +194,10 @@ public class PanAndZoomCameraControl
 	 */
 	protected void pan( final ControlInputEvent event )
 	{
-		final View3D view = _view;
-		final Matrix3D scene2view = _dragStartScene2View;
-
-		final double toUnits = view.getPixelsToUnitsFactor();
-
-		final double dx =  toUnits * (double)event.getDragDeltaX();
-		final double dy = -toUnits * (double)event.getDragDeltaY();
-
-		view.setScene2View( scene2view.plus( dx , dy , 0.0 ) );
+		double toUnits = _view.getProjector().imageToViewScale( 0 );
+		double dx = toUnits * event.getDragDeltaX();
+		double dy = -toUnits * event.getDragDeltaY();
+		setScene2View( _dragStartScene2View.plus( dx, dy, 0 ) );
 	}
 
 	/**

--- a/core/src/main/java/ab/j3d/view/Projector.java
+++ b/core/src/main/java/ab/j3d/view/Projector.java
@@ -1,7 +1,6 @@
-/* $Id$
- * ====================================================================
+/*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2011 Peter S. Heijnen
+ * Copyright (C) 1999-2025 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,7 +15,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- * ====================================================================
  */
 package ab.j3d.view;
 
@@ -30,9 +28,8 @@ import org.jetbrains.annotations.*;
  * surface (image plate, view plane, screen) and back. Implementations
  * of this class provide several projection methods.
  *
- * @author  Rob Veneberg
- * @author  Peter S. Heijnen
- * @version $Revision$ $Date$
+ * @author Rob Veneberg
+ * @author Peter S. Heijnen
  */
 public abstract class Projector
 {
@@ -635,6 +632,14 @@ public abstract class Projector
 	public abstract Vector3D imageToView( double imageX, double imageY, double viewZ );
 
 	/**
+	 * Returns the scale of a single pixel in view coordinates at the given
+	 * viewing distance.
+	 *
+	 * @param viewZ Z-coordinate relative to view plane (view units).
+	 */
+	public abstract double imageToViewScale( double viewZ );
+
+	/**
 	 * Get a ray originating from a (mouse) pointer at (<code>pointerX</code>,
 	 * <code>pointerY</code>) on the image plate, pointing into the view volume.
 	 * <p />
@@ -724,52 +729,56 @@ public abstract class Projector
 		}
 
 		@Override
-		public void project( final double[] result, final int resultOffset, final double viewX, final double viewY, final double viewZ )
+		public void project( double[] result, int resultOffset, double viewX, double viewY, double viewZ )
 		{
-			final double f = _view2pixels / ( 1.0 - ( viewZ + _eyeDistance ) / _eyeDistance );
-			final double x = _imageCenterX + f * viewX;
-			final double y = _imageCenterY - f * viewY;
+			double f = viewToImageScale( viewZ );
+			double x = _imageCenterX - f * viewX;
+			double y = _imageCenterY + f * viewY;
 
 			result[ resultOffset ] = x;
 			result[ resultOffset + 1 ] = y;
 		}
 
 		@Override
-		public void project( final float[] result, final int resultOffset, final double viewX, final double viewY, final double viewZ )
+		public void project( float[] result, int resultOffset, double viewX, double viewY, double viewZ )
 		{
-			final double f = _view2pixels / ( 1.0 - ( viewZ + _eyeDistance ) / _eyeDistance );
-			final double x = _imageCenterX + f * viewX;
-			final double y = _imageCenterY - f * viewY;
+			double f = viewToImageScale( viewZ );
+			double x = _imageCenterX - f * viewX;
+			double y = _imageCenterY + f * viewY;
 
-			result[ resultOffset ] = (float) x;
-			result[ resultOffset + 1 ] = (float) y;
+			result[ resultOffset ] = (float)x;
+			result[ resultOffset + 1 ] = (float)y;
 		}
 
 		@Override
-		public void project( final int[] result, final int resultOffset, final double viewX, final double viewY, final double viewZ )
+		public void project( int[] result, int resultOffset, double viewX, double viewY, double viewZ )
 		{
-			final double f = _view2pixels / ( 1.0 - ( viewZ + _eyeDistance ) / _eyeDistance );
-			final double x = _imageCenterX + f * viewX;
-			final double y = _imageCenterY - f * viewY;
+			double f = viewToImageScale( viewZ );
+			double x = _imageCenterX - f * viewX;
+			double y = _imageCenterY + f * viewY;
 
-			result[ resultOffset ] = (int) Math.floor( x + 0.5);
-			result[ resultOffset + 1 ] = (int) Math.floor( y + 0.5 );
+			result[ resultOffset ] = (int)Math.floor( x + 0.5 );
+			result[ resultOffset + 1 ] = (int)Math.floor( y + 0.5 );
 		}
 
 		@Override
-		public Vector3D imageToView( final double imageX, final double imageY, final double viewZ )
+		public Vector3D imageToView( double imageX, double imageY, double viewZ )
 		{
-			final double centerX     = (double)( _imageCenterX );
-			final double centerY     = (double)( _imageCenterY );
-			final double view2pixels = _view2pixels;
-			final double eyeDistance = _eyeDistance;
-
-			final double f = view2pixels / ( 1.0 - ( viewZ + eyeDistance ) / eyeDistance );
-
-			final double viewX = ( imageX - centerX ) / f;
-			final double viewY = ( centerY - imageY ) / f;
-
+			double f = imageToViewScale( viewZ );
+			double viewX = ( _imageCenterX - imageX ) * f;
+			double viewY = ( imageY - _imageCenterY ) * f;
 			return new Vector3D( viewX, viewY, viewZ );
+		}
+
+		private double viewToImageScale( double viewZ )
+		{
+			return _view2pixels / ( ( viewZ + _eyeDistance ) / _eyeDistance - 1.0 );
+		}
+
+		@Override
+		public double imageToViewScale( double viewZ )
+		{
+			return ( ( viewZ + _eyeDistance ) / _eyeDistance - 1.0 ) / _view2pixels;
 		}
 
 		@Override
@@ -904,6 +913,12 @@ public abstract class Projector
 			final double viewY = ( centerY - imageY ) / view2pixels;
 
 			return new Vector3D( viewX, viewY, viewZ );
+		}
+
+		@Override
+		public double imageToViewScale( double viewZ )
+		{
+			return 1.0 / _view2pixels;
 		}
 
 		@Override

--- a/core/src/test/java/ab/j3d/view/TestProjector.java
+++ b/core/src/test/java/ab/j3d/view/TestProjector.java
@@ -1,7 +1,6 @@
-/* $Id$
- * ====================================================================
+/*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2011 Peter S. Heijnen
+ * Copyright (C) 1999-2025 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,105 +15,113 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
- * ====================================================================
  */
 package ab.j3d.view;
 
 import ab.j3d.*;
 import ab.j3d.model.*;
-import junit.framework.*;
+import static org.junit.Assert.*;
+import org.junit.*;
 
 /**
  * This class tests the {@link Projector} class.
  *
- * @author  Mart Slot
- * @author  Peter S. Heijnen
- * @version $Revision$ $Date$
+ * @author Mart Slot
+ * @author Peter S. Heijnen
  */
 public class TestProjector
-	extends TestCase
 {
-	/**
-	 * Name of this class.
-	 */
-	private static final String CLASS_NAME = TestProjector.class.getName();
-
-	/**
-	 * Test the {@link Projector#imageToView} method.
-	 *
-	 * @throws  Exception if the test fails.
-	 */
-	public void testImageToView()
-		throws Exception
+	@Test
+	public void testProject_Perspective()
 	{
-		System.out.println( CLASS_NAME + ".testImageToView()" );
+		Projector projector = Projector.createInstance( ProjectionPolicy.PERSPECTIVE, 100, 100, 1.0, Scene.M, 0.1, 1000.0, Math.toRadians( 45.0 ), 1.0 );
+		assertArrayEquals( new int[] { 0, 100 }, projector.project( new double[] { 41.42, 41.42, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 0, 0 }, projector.project( new double[] { 41.42, -41.42, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 100, 100 }, projector.project( new double[] { -41.42, 41.42, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 100, 0 }, projector.project( new double[] { -41.42, -41.42, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 50, 50 }, projector.project( new double[] { 0, 0, 100.0 }, new int[ 2 ], 1 ) );
+	}
 
-		System.out.println( " - PerspectiveProjector" );
+	@Test
+	public void testProject_Parallel()
+	{
+		Projector projector = Projector.createInstance( ProjectionPolicy.PARALLEL, 100, 100, 1.0, Scene.M, 0.1, 1000.0, Math.toRadians( 45.0 ), 1.0 );
+		assertArrayEquals( new int[] { 0, 0 }, projector.project( new double[] { -50, 50, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 0, 100 }, projector.project( new double[] { -50, -50, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 100, 0 }, projector.project( new double[] { 50, 50, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 100, 100 }, projector.project( new double[] { 50, -50, 100.0 }, new int[ 2 ], 1 ) );
+		assertArrayEquals( new int[] { 50, 50 }, projector.project( new double[] { 0, 0, 100.0 }, new int[ 2 ], 1 ) );
+	}
 
-		Projector projector = Projector.createInstance( ProjectionPolicy.PERSPECTIVE, 100, 100, 1.0, Scene.M, 0.1, 1000.0, Math.toRadians( 45.0 ), 1.0);
+	@Test
+	public void testImageToView_Perspective()
+	{
+		Projector projector = Projector.createInstance( ProjectionPolicy.PERSPECTIVE, 100, 100, 1.0, Scene.M, 0.1, 1000.0, Math.toRadians( 45.0 ), 1.0 );
 
 		Vector3D screen = new Vector3D( 0.0, 100.0, 100.0 );
 		Vector3D world = projector.imageToView( screen.x, screen.y, screen.z );
 		Vector3D expected = new Vector3D( 41.42, 41.42, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 0.0, 0.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( 41.42, -41.42, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 100.0, 100.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( -41.42, 42.42, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 100.0, 0.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( -41.42, -41.42, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 50.0, 50.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( 0.0, 0.0, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
+	}
 
-		System.out.println( " - ParallelProjector" );
+	@Test
+	public void testImageToView_Parallel()
+	{
+		Projector projector = Projector.createInstance( ProjectionPolicy.PARALLEL, 100, 100, 1.0, Scene.M, 0.1, 1000.0, Math.toRadians( 45.0 ), 1.0 );
 
-		projector = Projector.createInstance( ProjectionPolicy.PARALLEL, 100, 100, 1.0, Scene.M, 0.1, 1000.0, Math.toRadians( 45.0 ), 1.0);
-
-		screen = new Vector3D( 0.0, 0.0, 100.0 );
-		world = projector.imageToView( screen.x, screen.y, screen.z );
-		expected = new Vector3D( -50.0, 50.0, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		Vector3D screen = new Vector3D( 0.0, 0.0, 100.0 );
+		Vector3D world = projector.imageToView( screen.x, screen.y, screen.z );
+		Vector3D expected = new Vector3D( -50.0, 50.0, 100.0 );
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 0.0, 100.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( -50.0, -50.0, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 100.0, 0.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( 50.0, 50.0, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 100.0, 100.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( 50.0, -50.0, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 
 		screen = new Vector3D( 50.0, 50.0, 100.0 );
 		world = projector.imageToView( screen.x, screen.y, screen.z );
 		expected = new Vector3D( 0.0, 0.0, 100.0 );
-		System.out.println( "    > testing " + screen.toString() );
-		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected.toString() + "  result: " + world.toString(), world.distanceTo(  expected ) < 1.0);
+		System.out.println( "    > testing " + screen );
+		assertTrue( "The calculated world coordinates do not match the expected coordinates. Expected: " + expected + "  result: " + world.toString(), world.distanceTo( expected ) < 1.0 );
 	}
 }


### PR DESCRIPTION
The panning rate in `FromToCameraControl` doesn’t take the view distance into account. That means that panning is too fast when nearby and too slow when far away.

This is fixed by determining the image-to-view scale in `Projector` for a given distance from the camera.