### PR TITLE
fix: ID-3404: JOGL renderer and off-screen view do not dispose all resources properly

### DIFF
--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/CoreShaderProgram.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/CoreShaderProgram.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.*;
  * Represents an OpenGL Shading Language (GLSL) shader program. This
  * implementation uses the core API, available in OpenGL 2.0 and above.
  *
- * @author  G. Meinders
+ * @author G. Meinders
  */
 public class CoreShaderProgram
 	implements ShaderProgram
@@ -53,7 +53,7 @@ public class CoreShaderProgram
 	/**
 	 * Constructs a new shader program.
 	 *
-	 * @param   name    Name for the program, for traceability.
+	 * @param name Name for the program, for traceability.
 	 */
 	public CoreShaderProgram( @Nullable final String name )
 	{
@@ -69,7 +69,7 @@ public class CoreShaderProgram
 	/**
 	 * Returns the underlying program object.
 	 *
-	 * @return  Program object.
+	 * @return Program object.
 	 */
 	public int getProgramObject()
 	{
@@ -129,7 +129,24 @@ public class CoreShaderProgram
 				throw new GLException( ( infoLog == null ) ? ( "'" + _name + "' shader(s) failed to link (sorry, no details available)." ) : ( "Linking of '" + _name + "' shader(s) failed: " + infoLog ) );
 			}
 
+			// Shaders can be detached after successful linking (https://registry.khronos.org/OpenGL-Refpages/gl4/html/glLinkProgram.xhtml)
+			detachShaders( gl2 );
+
 			_linked = true;
+		}
+	}
+
+	private void detachShaders( GL2ES2 gl2 )
+	{
+		// Detach shaders before deleting to prevent memory leak.
+		// According to the standard it should be possible to detach immediately
+		// after linking, but alas, that breaks shadow maps on my machine.
+		int[] count = new int[ 1 ];
+		int[] ids = new int[ 100 ];
+		gl2.glGetAttachedShaders( _program, ids.length, count, 0, ids, 0 );
+		for ( int i = 0; i < count[ 0 ]; i++ )
+		{
+			gl2.glDetachShader( _program, ids[ i ] );
 		}
 	}
 
@@ -162,7 +179,7 @@ public class CoreShaderProgram
 		gl2.glGetProgramiv( _program, GL2ES2.GL_INFO_LOG_LENGTH, infoLogLength, 0 );
 
 		final String infoLog;
-		if( infoLogLength[ 0 ] == 0 )
+		if ( infoLogLength[ 0 ] == 0 )
 		{
 			infoLog = null;
 		}
@@ -197,6 +214,7 @@ public class CoreShaderProgram
 	{
 		final GL gl = GLU.getCurrentGL();
 		final GL2ES2 gl2 = gl.getGL2ES2();
+		detachShaders( gl2 );
 		gl2.glDeleteProgram( _program );
 	}
 

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/CoreShaderProgram.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/CoreShaderProgram.java
@@ -1,6 +1,6 @@
 /*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2019 Peter S. Heijnen
+ * Copyright (C) 1999-2026 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLOffscreenView.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLOffscreenView.java
@@ -37,7 +37,7 @@ import com.jogamp.opengl.util.awt.*;
  * @author Gerrit Meinders
  */
 public class JOGLOffscreenView
-extends OffscreenView3D
+	extends OffscreenView3D
 {
 	/**
 	 * Engine that created this view.
@@ -282,7 +282,7 @@ extends OffscreenView3D
 
 			try
 			{
-				Threading.invokeOnOpenGLThread(true, new Runnable()
+				Threading.invokeOnOpenGLThread( true, new Runnable()
 				{
 					@Override
 					public void run()
@@ -314,11 +314,22 @@ extends OffscreenView3D
 		{
 			try
 			{
+				if ( context.makeCurrent() == GLContext.CONTEXT_NOT_CURRENT )
+				{
+					throw new GLException( "Failed to make offscreen context current before disposal." );
+				}
+
+				if ( _renderer != null )
+				{
+					_renderer.dispose();
+					_renderer = null;
+				}
+
 				context.release();
 			}
 			catch ( final GLException gle )
 			{
-				// expected
+				gle.printStackTrace();
 			}
 			finally
 			{
@@ -326,7 +337,6 @@ extends OffscreenView3D
 			}
 		}
 
-		_renderer = null;
 		_capabilities = null;
 
 		final JOGLGraphics2D graphics2D = _graphics2D;

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLOffscreenView.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLOffscreenView.java
@@ -1,6 +1,6 @@
 /*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2019 Peter S. Heijnen
+ * Copyright (C) 1999-2026 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -163,7 +163,19 @@ public class JOGLOffscreenView
 		controlInput.addControlInputListener( defaultViewControl );
 		addOverlay( defaultViewControl );
 
-		update();
+		GLContext context = drawable.getContext();
+		if ( context.makeCurrent() == GLContext.CONTEXT_NOT_CURRENT )
+		{
+			throw new GLException( "Failed to make offscreen context current." );
+		}
+		try
+		{
+			init( drawable );
+		}
+		finally
+		{
+			context.release();
+		}
 	}
 
 	@Override
@@ -186,18 +198,6 @@ public class JOGLOffscreenView
 				if ( context.makeCurrent() == GLContext.CONTEXT_NOT_CURRENT )
 				{
 					throw new GLException( "Failed to make offscreen context current." );
-				}
-
-				if ( _capabilities == null ) // TODO: Find a better check to init only once.
-				{
-					init( drawable );
-
-					// FIXME: Release context and make it current again. Don't know why, but image is empty otherwise.
-					context.release();
-					if ( context.makeCurrent() == GLContext.CONTEXT_NOT_CURRENT )
-					{
-						throw new GLException( "Failed to make offscreen context current." );
-					}
 				}
 
 				try
@@ -326,10 +326,6 @@ public class JOGLOffscreenView
 				}
 
 				context.release();
-			}
-			catch ( final GLException gle )
-			{
-				gle.printStackTrace();
 			}
 			finally
 			{

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
@@ -463,6 +463,12 @@ public class JOGLRenderer
 	{
 		_shaderManager.dispose();
 		_geometryObjectManager.dispose();
+
+		if ( _shadowMap != null )
+		{
+			_shadowMap.delete();
+			_shadowMap = null;
+		}
 	}
 
 	/**
@@ -2141,7 +2147,7 @@ public class JOGLRenderer
 	 * Tree walker that takes level of detail of {@link Object3D}s into account.
 	 */
 	private class LevelOfDetailTreeWalker
-	extends Node3DTreeWalker
+		extends Node3DTreeWalker
 	{
 		/**
 		 * Calculates projected object bounds.
@@ -2174,16 +2180,16 @@ public class JOGLRenderer
 								final Matrix3D object2View = object2scene.multiply( scene2View );
 
 								final double[] points =
-								{
-								boundingBox.v1.x, boundingBox.v1.y, boundingBox.v1.z,
-								boundingBox.v2.x, boundingBox.v1.y, boundingBox.v1.z,
-								boundingBox.v1.x, boundingBox.v2.y, boundingBox.v1.z,
-								boundingBox.v2.x, boundingBox.v2.y, boundingBox.v1.z,
-								boundingBox.v1.x, boundingBox.v1.y, boundingBox.v2.z,
-								boundingBox.v2.x, boundingBox.v1.y, boundingBox.v2.z,
-								boundingBox.v1.x, boundingBox.v2.y, boundingBox.v2.z,
-								boundingBox.v2.x, boundingBox.v2.y, boundingBox.v2.z
-								};
+									{
+										boundingBox.v1.x, boundingBox.v1.y, boundingBox.v1.z,
+										boundingBox.v2.x, boundingBox.v1.y, boundingBox.v1.z,
+										boundingBox.v1.x, boundingBox.v2.y, boundingBox.v1.z,
+										boundingBox.v2.x, boundingBox.v2.y, boundingBox.v1.z,
+										boundingBox.v1.x, boundingBox.v1.y, boundingBox.v2.z,
+										boundingBox.v2.x, boundingBox.v1.y, boundingBox.v2.z,
+										boundingBox.v1.x, boundingBox.v2.y, boundingBox.v2.z,
+										boundingBox.v2.x, boundingBox.v2.y, boundingBox.v2.z
+									};
 
 								object2View.transform( points, points, 8 );
 								projector.project( points, points, 8 );

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
@@ -142,12 +142,12 @@ public class JOGLRenderer
 	/**
 	 * Framebuffer for multi-pass rendering.
 	 */
-	private ColorDepthFramebuffer _accumulationBuffer1 = new ColorDepthFramebuffer();
+	private final ColorDepthFramebuffer _accumulationBuffer1 = new ColorDepthFramebuffer();
 
 	/**
 	 * Additional framebuffer for multi-pass rendering on MacOS.
 	 */
-	private ColorDepthFramebuffer _accumulationBuffer2 = new ColorDepthFramebuffer();
+	private final ColorDepthFramebuffer _accumulationBuffer2 = new ColorDepthFramebuffer();
 
 	/**
 	 * Whether color should be rendered for shadow maps, instead of only depth.
@@ -472,6 +472,9 @@ public class JOGLRenderer
 			_geometryObjectManager.dispose();
 			_geometryObjectManager = null;
 		}
+
+		_accumulationBuffer1.delete();
+		_accumulationBuffer2.delete();
 
 		if ( _shadowMap != null )
 		{

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
@@ -1,6 +1,6 @@
 /*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2019 Peter S. Heijnen
+ * Copyright (C) 1999-2026 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/JOGLRenderer.java
@@ -461,8 +461,17 @@ public class JOGLRenderer
 	 */
 	public void dispose()
 	{
-		_shaderManager.dispose();
-		_geometryObjectManager.dispose();
+		if ( _shaderManager != null )
+		{
+			_shaderManager.dispose();
+			_shaderManager = null;
+		}
+
+		if (_geometryObjectManager != null )
+		{
+			_geometryObjectManager.dispose();
+			_geometryObjectManager = null;
+		}
 
 		if ( _shadowMap != null )
 		{

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShaderManager.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShaderManager.java
@@ -435,6 +435,8 @@ public class ShaderManager
 	 */
 	public void dispose()
 	{
+		useShader( null );
+
 		for ( final ShaderProgram shaderProgram : _shaderPrograms.values() )
 		{
 			shaderProgram.dispose();
@@ -446,8 +448,6 @@ public class ShaderManager
 			shader.dispose();
 		}
 		_shaders.clear();
-
-		useShader( null );
 	}
 
 	/**

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShaderManager.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShaderManager.java
@@ -200,11 +200,14 @@ public class ShaderManager
 		if ( shaderImplementation != null )
 		{
 			final ShaderProgram shaderProgram = shaderImplementation.createProgram( name );
+			_shaderPrograms.put( name, shaderProgram );
+
 			for ( final String shader : shaders )
 			{
 				shaderProgram.attach( getShader( shader ) );
 			}
-			_shaderPrograms.put( name, shaderProgram );
+
+			shaderProgram.link();
 		}
 	}
 

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShaderManager.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShaderManager.java
@@ -1,6 +1,6 @@
 /*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2019 Peter S. Heijnen
+ * Copyright (C) 1999-2026 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShadowMap.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/ShadowMap.java
@@ -1,6 +1,6 @@
 /*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2019 Peter S. Heijnen
+ * Copyright (C) 1999-2026 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -57,7 +57,7 @@ import com.jogamp.opengl.glu.*;
  * }
  * </pre>
  *
- * @author  G. Meinders
+ * @author G. Meinders
  */
 public class ShadowMap
 {
@@ -65,8 +65,7 @@ public class ShadowMap
 	 * Transformation from normalized screen coordinates (-1 to 1) to
 	 * texture coordinates (0 to 1).
 	 */
-	private static final double[] SCREEN_TO_TEXTURE =
-	{
+	private static final double[] SCREEN_TO_TEXTURE = {
 		0.5, 0.0, 0.0, 0.0,
 		0.0, 0.5, 0.0, 0.0,
 		0.0, 0.0, 0.5, 0.0,
@@ -118,10 +117,12 @@ public class ShadowMap
 	 */
 	private double[] _modelviewMatrix;
 
+	private int[] _textures;
+
 	/**
 	 * Constructs a new shadow map of the given size.
 	 *
-	 * @param   shadowSize      Length and width of the shadow map.
+	 * @param shadowSize Length and width of the shadow map.
 	 */
 	public ShadowMap( final int shadowSize )
 	{
@@ -133,9 +134,9 @@ public class ShadowMap
 	 * is rendered in addition to a depth map. This can be used to easily view
 	 * what the light 'sees'.
 	 *
-	 * @param   shadowSize      Length and width of the shadow map.
-	 * @param   renderColorMap  <code>true</code> to render a color map;
-	 *                          otherwise only depth is rendered.
+	 * @param shadowSize     Length and width of the shadow map.
+	 * @param renderColorMap <code>true</code> to render a color map;
+	 *                       otherwise only depth is rendered.
 	 */
 	public ShadowMap( final int shadowSize, final boolean renderColorMap )
 	{
@@ -156,8 +157,8 @@ public class ShadowMap
 	/**
 	 * Sets the light to render the shadow map for.
 	 *
-	 * @param   light       Light.
-	 * @param   transform   Light to scene transform.
+	 * @param light     Light.
+	 * @param transform Light to scene transform.
 	 */
 	public void setLight( final Light3D light, final Matrix3D transform )
 	{
@@ -168,21 +169,22 @@ public class ShadowMap
 	/**
 	 * Initializes the shadow map.
 	 *
-	 * @param   gl  OpenGL pipeline.
+	 * @param gl OpenGL pipeline.
 	 */
 	public void init( final GL gl )
 	{
 		final int textureCount = _renderColorMap ? 2 : 1;
 
-		final int[] textures = new int[ textureCount ];
-		gl.glGenTextures( textures.length, textures, 0 );
+		_textures = new int[ textureCount ];
+		gl.glGenTextures( _textures.length, _textures, 0 );
 
 		final Framebuffer framebuffer = new Framebuffer();
+		_framebuffer = framebuffer;
 		framebuffer.bind();
 
 		final int size = _size;
 		{
-			final int depthTexture = textures[ 0 ];
+			final int depthTexture = _textures[ 0 ];
 			gl.glBindTexture( GL.GL_TEXTURE_2D, depthTexture );
 			gl.glTexImage2D( GL.GL_TEXTURE_2D, 0, GL2ES2.GL_DEPTH_COMPONENT, size, size, 0, GL2ES2.GL_DEPTH_COMPONENT, GL.GL_UNSIGNED_INT, null );
 			gl.glTexParameteri( GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR );
@@ -196,7 +198,7 @@ public class ShadowMap
 
 		if ( _renderColorMap )
 		{
-			final int colorTexture = textures[ 1 ];
+			final int colorTexture = _textures[ 1 ];
 			gl.glBindTexture( GL.GL_TEXTURE_2D, colorTexture );
 			gl.glTexImage2D( GL.GL_TEXTURE_2D, 0, GL.GL_RGBA, size, size, 0, GL.GL_RGBA, GL.GL_UNSIGNED_INT, null );
 			gl.glTexParameteri( GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR );
@@ -214,14 +216,30 @@ public class ShadowMap
 
 		framebuffer.check();
 		Framebuffer.unbind();
-		_framebuffer = framebuffer;
+	}
+
+	public void delete()
+	{
+		GL gl = GLContext.getCurrentGL();
+
+		if ( _framebuffer != null )
+		{
+			_framebuffer.delete();
+			_framebuffer = null;
+		}
+
+		if ( _textures != null )
+		{
+			gl.glDeleteTextures( _textures.length, _textures, 0 );
+			_textures = null;
+		}
 	}
 
 	/**
 	 * Prepares for rendering of the shadow map.
 	 *
-	 * @param   gl      OpenGL pipeline.
-	 * @param   scene   Scene being rendered.
+	 * @param gl    OpenGL pipeline.
+	 * @param scene Scene being rendered.
 	 */
 	public void begin( final GL gl, final Scene scene )
 	{
@@ -320,7 +338,7 @@ public class ShadowMap
 	/**
 	 * Finishes rendering of the shadow map.
 	 *
-	 * @param   gl      OpenGL pipeline.
+	 * @param gl OpenGL pipeline.
 	 */
 	public void end( final GL gl )
 	{
@@ -336,7 +354,7 @@ public class ShadowMap
 	/**
 	 * Loads the projection matrix for projecting the shadow map on the scene.
 	 *
-	 * @param   gl      OpenGL pipeline.
+	 * @param gl OpenGL pipeline.
 	 */
 	public void loadProjectionMatrix( final GL gl )
 	{
@@ -349,7 +367,7 @@ public class ShadowMap
 	/**
 	 * Returns the depth texture.
 	 *
-	 * @return  OpenGL texture.
+	 * @return OpenGL texture.
 	 */
 	public int getDepthTexture()
 	{
@@ -359,7 +377,7 @@ public class ShadowMap
 	/**
 	 * Returns the color texture, if any.
 	 *
-	 * @return  OpenGL texture.
+	 * @return OpenGL texture.
 	 */
 	public int getColorTexture()
 	{

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/TextureCache.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/TextureCache.java
@@ -127,17 +127,21 @@ public class TextureCache
 		{
 			Map.Entry<Object, TextureProxy> entry = i.next();
 			TextureProxy textureProxy = entry.getValue();
+			Texture texture = textureProxy.getTexture();
 
 			/*
 			 * If texture data is still available, a new texture can be created.
 			 * Otherwise, the proxy is of no use anymore.
 			 */
+			boolean notLoaded = texture == null && !textureProxy.isTextureDataSet();
 
-			// If the context is reused, the texture may still be valid.
-			Texture texture = textureProxy.getTexture();
-			boolean validTexture = texture != null && gl.glIsTexture( texture.getTextureObject() );
+			/*
+			 * If the texture object was already created, but is no longer valid
+			 * then it has to be recreated.
+			 */
+			boolean invalidTexture = texture != null && !gl.glIsTexture( texture.getTextureObject() );
 
-			if ( !validTexture && !textureProxy.isTextureDataSet() )
+			if ( invalidTexture || notLoaded )
 			{
 				i.remove();
 				_alpha.remove( entry.getKey() );

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/TextureCache.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/TextureCache.java
@@ -1,6 +1,6 @@
 /*
  * AsoBrain 3D Toolkit
- * Copyright (C) 1999-2021 Peter S. Heijnen
+ * Copyright (C) 1999-2026 Peter S. Heijnen
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/jogl2/src/main/java/ab/j3d/awt/view/jogl/TextureCache.java
+++ b/jogl2/src/main/java/ab/j3d/awt/view/jogl/TextureCache.java
@@ -132,7 +132,12 @@ public class TextureCache
 			 * If texture data is still available, a new texture can be created.
 			 * Otherwise, the proxy is of no use anymore.
 			 */
-			if ( !textureProxy.isTextureDataSet() )
+
+			// If the context is reused, the texture may still be valid.
+			Texture texture = textureProxy.getTexture();
+			boolean validTexture = texture != null && gl.glIsTexture( texture.getTextureObject() );
+
+			if ( !validTexture && !textureProxy.isTextureDataSet() )
 			{
 				i.remove();
 				_alpha.remove( entry.getKey() );
@@ -400,7 +405,7 @@ public class TextureCache
 	 * @throws IOException if an I/O error occurs while reading the image.
 	 */
 	public @Nullable BufferedImage loadImage( TextureMap textureMap )
-	throws IOException
+		throws IOException
 	{
 		return _textureLibrary.loadImage( textureMap );
 	}
@@ -411,7 +416,7 @@ public class TextureCache
 	 * runtime from stopping.
 	 */
 	private static class DaemonThreadFactory
-	implements ThreadFactory
+		implements ThreadFactory
 	{
 		/**
 		 * Thread group for new threads.


### PR DESCRIPTION
Several issues are fixed that greatly reduce the amount of resources leaked during off-screen rendering:

* JOGLOffscreenView doesn't dispose JOGLRenderer at all
* JOGLRenderer does not dispose ShadowMap
* ShadowMap does not dispose the textures it creates
* JOGLRenderer does not dispose of its accumulation buffers, which hold texture objects
* TextureCache removes texture proxies for valid textures when context is re-used
* ShaderManager should detach shaders from the program after linking

Unfortunately it's not perfect yet. But that may or may not be an issue with this library.